### PR TITLE
Update main.tf

### DIFF
--- a/opentofu/main.tf
+++ b/opentofu/main.tf
@@ -31,7 +31,7 @@ resource "google_cloud_run_v2_service" "cloud_run_service" {
         name  = "SLACK_API_TOKEN"
         value = var.slack_api_token
       }
-      image = "europe-west2-docker.pkg.dev/${var.gcp_project_name}/${var.gcp_project_name}-gcr/${var.gcp_project_name}-image:latest"
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
       name  = "${var.gcp_project_name}-image-1"
       ports {
         container_port = 8080


### PR DESCRIPTION
During the initial tofu apply, the Cloud Run service was created but partially failed. By default, Cloud Run service creation is expected to return a deployment URL. However, this failed because the specified image did not exist yet - the Artifact Registry was empty at the time.

As a result, the resource entered a Tainted Provision state, meaning it was successfully provisioned but not functioning correctly as defined by the provider.

*Solution*:
Provision the initial Cloud Run service using a publicly accessible dummy image from Google Artifact Registry (GAR).

Later, override the image in a new Cloud Run revision when the build_and_deploy.yml GitHub Action runs for the first time.